### PR TITLE
fix: RMET-1007 - Added android:exported to manifest in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,11 +13,12 @@
     <hook type="after_prepare" src="hooks/androidSetToolsTag.js" />
 
     <config-file target="AndroidManifest.xml" parent="application">        
-    <activity android:name="com.outsystems.plugins.barcodescanner.CustomScannerActivity"
-            android:screenOrientation="fullSensor"
-            android:stateNotNeeded="true"
-            android:theme="@style/zxing_CaptureTheme"
-            android:windowSoftInputMode="stateAlwaysHidden"></activity>    
+      <activity android:name="com.outsystems.plugins.barcodescanner.CustomScannerActivity"
+              android:screenOrientation="fullSensor"
+              android:stateNotNeeded="true"
+              android:exported="false"
+              android:theme="@style/zxing_CaptureTheme"
+              android:windowSoftInputMode="stateAlwaysHidden"></activity>    
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest">


### PR DESCRIPTION
## Description
For Android 12, activities with intent-filter now require the property android:exported to be defined.

## Context
Added android:exported to activity in plugin.xml, for future prevention.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
