### PR TITLE
RMET-1261 Barcode Plugin - Send an ERROR instead of a NO_RESULT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix: In iOS when cancelling the barcode scanner view, send an ERROR instead of a NO_RESULT (https://outsystemsrd.atlassian.net/browse/RMET-1261)
+
 ## [1.0.4]
 - Chore: New plugin release to include metadata tag for MABS 7.2.0 compatibility
 

--- a/src/ios/OSBarcodeScanner.m
+++ b/src/ios/OSBarcodeScanner.m
@@ -55,7 +55,7 @@ CDVInvokedUrlCommand* cdvCommand;
     if (str != nil && [str length] > 0 && !([str isEqual: @"User closed before getting a result"])) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: str];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString: str];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: str];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:cdvCommand.callbackId];
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
To uniformize with Android. Furthermore, an ERROR is what the OS wrapper is expecting.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1261

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally in XCode.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
