### PR TITLE
RMET-746 ::: iOS ::: Fix PDF417 Scan Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fix: iOS | Reading PDF417 code types causes a crash (https://outsystemsrd.atlassian.net/browse/RMET-746).
 
 ## [1.0.7]
 

--- a/src/ios/ScannerViewController.m
+++ b/src/ios/ScannerViewController.m
@@ -341,7 +341,13 @@
     CGAffineTransform inverse = CGAffineTransformInvert(_captureSizeTransform);
     NSMutableArray *points = [[NSMutableArray alloc] init];
     NSString *location = @"";
-    for (ZXResultPoint *resultPoint in result.resultPoints) {
+    
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id item, NSDictionary *unused) {
+        return ![item isKindOfClass:NSNull.class];
+    }];
+    NSArray *resultPoints = [result.resultPoints filteredArrayUsingPredicate:predicate];
+    
+    for (ZXResultPoint *resultPoint in resultPoints) {
         CGPoint cgPoint = CGPointMake(resultPoint.x, resultPoint.y);
         CGPoint transformedPoint = CGPointApplyAffineTransform(cgPoint, inverse);
         transformedPoint = [self.scanRectView convertPoint:transformedPoint toView:self.scanRectView.window];


### PR DESCRIPTION
## Description
Before iterating through the scan's result points, remove the null values that are causing the crash.

A Sample App build was generated to test the fix: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=eb73dfb5512ac0fbb639ff4750b6053a9e3afe42

## Context
https://outsystemsrd.atlassian.net/browse/RMET-746

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
