### PR TITLE
RMET-2036 Barcode Plugin - Remove dependency to jcenter from Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+# 16-12-2022
+- Fix: Android | Remove dependency to jcenter from Gradle (https://outsystemsrd.atlassian.net/browse/RMET-2036).
+
 ## [1.0.8]
 - Fix: iOS | Reading PDF417 code types causes a crash (https://outsystemsrd.atlassian.net/browse/RMET-746).
 

--- a/build-extras-zxing.gradle
+++ b/build-extras-zxing.gradle
@@ -1,5 +1,4 @@
-repositories{    
- jcenter()
+repositories{
    flatDir {
      dirs 'src/main/libs'
    }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- JCenter is being discontinued, and so we should remove all references to it.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2036

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 and 9 builds, and also tested the plugin on an Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
