### PR TITLE
fix(ios): use podspec tag for cordova-ios 7 support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -75,8 +75,15 @@
     <header-file src="src/ios/ScannerViewController.h"/>
     <source-file src="src/ios/ScannerViewController.xib"/>
     <resource-file src="src/ios/BarcodeLocal.xcassets"/>
-    
-    <framework src="ZXingObjC" type="podspec" spec=":git => 'https://github.com/OutSystems/ZXingObjC.git', :tag => '3.6.4'"/>
+
+    <podspec>
+        <config>
+            <source url="https://cdn.cocoapods.org"/>
+        </config>
+        <pods>
+            <pod name="ZXingObjC" spec=":git => 'https://github.com/OutSystems/ZXingObjC.git', :tag => '3.6.4'" />
+        </pods>
+    </podspec>
     
   </platform>
 </plugin>


### PR DESCRIPTION
## Description
`framework` tag with `type="podspec"` was deprecated and has been removed in cordova-ios 7.0.0.

This PR replaces the `framework` tag usage with the `podspec` tag.

The `podspec` tag was introduced in cordova-ios 5.0.0, so not sure if this change could be considered breaking as it's not indicated which cordova-ios versions the plugin supports.

The change could be simplified by removing this block, but that would require cordova-ios 6.2.0
```
<config>
    <source url="https://cdn.cocoapods.org"/>
</config>
```

cordova-ios 5.0.0 was released around 4.5 years, and 6.2.0 around 2.5 years.

## Context


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
