### PR TITLE
RMET-2850 ::: Replace "podspec" Inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Chore: iOS | Use `podspec` element instead of it being a `framework` attribute.
+
 ## [1.0.9]
 
 # 16-12-2022

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,11 @@
     <source-file src="src/ios/ScannerViewController.xib"/>
     <resource-file src="src/ios/BarcodeLocal.xcassets"/>
     
-    <framework src="ZXingObjC" type="podspec" spec=":git => 'https://github.com/OutSystems/ZXingObjC.git', :tag => '3.6.4'"/>
+    <podspec>
+        <pods>
+            <pod name="ZXingObjC" git="https://github.com/OutSystems/ZXingObjC.git" tag="3.6.4" />
+        </pods>
+    </podspec>
     
   </platform>
 </plugin>


### PR DESCRIPTION
## Description
Import the `ZXingObjC` dependency through the `podspec` attribute instead of `framework`. This change is required by MABS 10.

In order to validate the PR, the following MABS builds were generated, one for 9.0 and another for 10.0. The `ZXingObjC` dependency folder structure should be identical in both versions:
- [MABS 9.0](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=7d10f001f5755b531bb9cc48a026d5e054ff03d9)
- [MABS 10.0](https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=05e4b6d54c85ef6adf457c2ff639d53e1033780c)

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2850

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests 
Done manually. The MABS 10.0 build doesn't fail anymore.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
